### PR TITLE
Update indivo/models/records_and_documents.py

### DIFF
--- a/indivo/models/records_and_documents.py
+++ b/indivo/models/records_and_documents.py
@@ -85,7 +85,7 @@ class Record(Object):
     for account in self.get_accounts_to_notify():
       # FIXME: does the account have the right to see notifications on this record?
 
-      #account.notify_account_of_new_message()
+      account.notify_account_of_new_message()
       Message.objects.create( account             = account, 
                               about_record        = self, 
                               external_identifier = external_identifier,


### PR DESCRIPTION
Uncommenting account.notify_account_of_new_message() now properly sends an email notification when inbox messages are received.
