### PR TITLE
Removed deprecated methods to be more compatible with Django 1.4

### DIFF
--- a/settings.py.default
+++ b/settings.py.default
@@ -155,9 +155,9 @@ ADMIN_MEDIA_PREFIX = '/media/'
 
 # List of callables that know how to import templates from various sources.
 TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.load_template_source',
-    'django.template.loaders.app_directories.load_template_source',
-#     'django.template.loaders.eggs.load_template_source',
+    'django.template.loaders.filesystem.Loader',
+    'django.template.loaders.app_directories.Loader',
+#     'django.template.loaders.eggs.Loader',
 )
 
 MIDDLEWARE_CLASSES = (

--- a/settings_rtfd.py
+++ b/settings_rtfd.py
@@ -156,9 +156,9 @@ ADMIN_MEDIA_PREFIX = '/media/'
 
 # List of callables that know how to import templates from various sources.
 TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.load_template_source',
-    'django.template.loaders.app_directories.load_template_source',
-#     'django.template.loaders.eggs.load_template_source',
+    'django.template.loaders.filesystem.Loader',
+    'django.template.loaders.app_directories.Loader',
+#     'django.template.loaders.eggs.Loader',
 )
 
 MIDDLEWARE_CLASSES = (


### PR DESCRIPTION
I've just removed a few [deprecated methods](https://docs.djangoproject.com/en/dev/internals/deprecation/) from `settings.py.default` and `settings_rtfd.py`.
